### PR TITLE
Rename "public" to "query"

### DIFF
--- a/.circleci/.env.circleci
+++ b/.circleci/.env.circleci
@@ -10,4 +10,4 @@ SS_DEFAULT_ADMIN_PASSWORD=password
 SS_ERROR_LOG="silverstripe.log"
 BIFROST_ENDPOINT="http://localhost"
 BIFROST_ENGINE_PREFIX="search-dev-main"
-BIFROST_PUBLIC_API_KEY="public-key"
+BIFROST_QUERY_API_KEY="public-key"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following environment variables are required for this module to function:
 
 * `BIFROST_ENDPOINT`
 * `BIFROST_ENGINE_PREFIX`
-* `BIFROST_PUBLIC_API_KEY`
+* `BIFROST_QUERY_API_KEY`
 
 ## Usage
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,12 +1,12 @@
 ---
 Name: discoverer-bifrost
 Only:
-    envvarset: 'BIFROST_PUBLIC_API_KEY'
+    envvarset: 'BIFROST_QUERY_API_KEY'
 ---
 SilverStripe\Core\Injector\Injector:
     Elastic\EnterpriseSearch\Client.searchClient:
         factory: SilverStripe\DiscovererBifrost\Service\ClientFactory
         constructor:
             host: '`BIFROST_ENDPOINT`'
-            token: '`BIFROST_PUBLIC_API_KEY`'
+            token: '`BIFROST_QUERY_API_KEY`'
             http_client: '%$GuzzleHttp\Client'

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -10,7 +10,7 @@ class ClientFactory implements Factory
 {
 
     private const ENDPOINT = 'BIFROST_ENDPOINT';
-    private const PUBLIC_API_KEY = 'BIFROST_PUBLIC_API_KEY';
+    private const QUERY_API_KEY = 'BIFROST_QUERY_API_KEY';
 
     /**
      * @throws Exception
@@ -28,7 +28,7 @@ class ClientFactory implements Factory
         }
 
         if (!$token) {
-            $missingEnvVars[] = self::PUBLIC_API_KEY;
+            $missingEnvVars[] = self::QUERY_API_KEY;
         }
 
         if ($missingEnvVars) {

--- a/tests/Service/ClientFactoryTest.php
+++ b/tests/Service/ClientFactoryTest.php
@@ -28,7 +28,7 @@ class ClientFactoryTest extends SapphireTest
 
     public function testCreateMissingEnvVars(): void
     {
-        $this->expectExceptionMessage('Required ENV vars missing: BIFROST_ENDPOINT, BIFROST_PUBLIC_API_KEY');
+        $this->expectExceptionMessage('Required ENV vars missing: BIFROST_ENDPOINT, BIFROST_QUERY_API_KEY');
 
         $clientFactory = new ClientFactory();
         // Expect this to throw our Exception as no params have been passed


### PR DESCRIPTION
To remove confusion between this and encryption keys private/public (which, is probably what most folks think of when they think of "private" keys).