### PR TITLE
bump dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-discoverer-elastic-enterprise": "dev-main",
+        "silverstripe/silverstripe-discoverer-elastic-enterprise": "1.0.0",
         "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {


### PR DESCRIPTION
Might also have to re-tag 1.0.0 to include this - it fixes an issue when installing the sdk package:

![image](https://github.com/user-attachments/assets/ea0995ca-61b0-4b0c-ba2e-a65687c4cac1)
