### PR TITLE
Remove analytics integration (not supported by API)

### DIFF
--- a/_config/adaptors.yml
+++ b/_config/adaptors.yml
@@ -10,6 +10,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\DiscovererBifrost\Service\Adaptors\QuerySuggestionAdaptor
   SilverStripe\Discoverer\Service\Interfaces\SpellingSuggestionAdaptor:
     class: SilverStripe\DiscovererBifrost\Service\Adaptors\SpellingSuggestionAdaptor
+  SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor:
+    class: SilverStripe\DiscovererBifrost\Service\Adaptors\ProcessAnalyticsAdaptor
   # Adaptors provided by the ElasticEnterprise dependency
   SilverStripe\Discoverer\Query\Facet\FacetAdaptor:
     class: SilverStripe\DiscovererElasticEnterprise\Query\Facet\FacetAdaptor
@@ -17,8 +19,6 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\DiscovererElasticEnterprise\Query\Filter\CriteriaAdaptor
   SilverStripe\Discoverer\Query\Filter\CriterionAdaptor:
     class: SilverStripe\DiscovererElasticEnterprise\Query\Filter\CriterionAdaptor
-  SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor:
-    class: SilverStripe\DiscovererElasticEnterprise\Service\Adaptors\ProcessAnalyticsAdaptor
   SilverStripe\Discoverer\Service\Interfaces\SearchAdaptor:
     class: SilverStripe\DiscovererElasticEnterprise\Service\Adaptors\SearchAdaptor
 

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -2,15 +2,33 @@
 
 namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
 
+use Psr\Log\LoggerInterface;
 use SilverStripe\Discoverer\Analytics\AnalyticsData;
 use SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor as ProcessAnalyticsAdaptorInterface;
 
+/**
+ * @deprecated Removed in version 3.0. We recommend that you remove SEARCH_ANALYTICS_ENABLED
+ */
 class ProcessAnalyticsAdaptor implements ProcessAnalyticsAdaptorInterface
 {
 
+    private ?LoggerInterface $logger = null;
+
+    private static array $dependencies = [
+        'logger' => '%$' . LoggerInterface::class . '.errorhandler',
+    ];
+
+    public function setLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
     public function process(AnalyticsData $analyticsData): void
     {
-        // Silently do nothing. Silverstripe Search does not support analytics
+        $this->logger->info(
+            'SilverStripe\DiscovererBifrost\Service\Adaptors\ProcessAnalyticsAdaptor is deprecated and will be removed'
+            . ' in version 3.0. We recommend that you remove SEARCH_ANALYTICS_ENABLED'
+        );
     }
 
 }

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
+
+use SilverStripe\Discoverer\Analytics\AnalyticsData;
+use SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor as ProcessAnalyticsAdaptorInterface;
+
+class ProcessAnalyticsAdaptor implements ProcessAnalyticsAdaptorInterface
+{
+
+    public function process(AnalyticsData $analyticsData): void
+    {
+        // Silently do nothing. Silverstripe Search does not support analytics
+    }
+
+}


### PR DESCRIPTION
## API Support

Support for analytics clicks is being removed from the Bifrost API, and will start returning 404 responses for any requests made to that endpoint.

The SDK does cover this sort of scenario by using a `try/catch`, but it does still log these errors, so folks might start filling their logging service with useless errors.

Ideally, applications would disable the analytics feature, but this change is here to silently ignores analytics clicks requests (if they persist).