### PR TITLE
Update Silverstripe Search Client. Add analytics tags to request object

### DIFF
--- a/_config/adaptors.yml
+++ b/_config/adaptors.yml
@@ -17,3 +17,5 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\DiscovererBifrost\Query\Filter\CriterionAdaptor
   SilverStripe\Discoverer\Service\Interfaces\SearchAdaptor:
     class: SilverStripe\DiscovererBifrost\Service\Adaptors\SearchAdaptor
+  SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor:
+    class: SilverStripe\DiscovererBifrost\Service\Adaptors\ProcessAnalyticsAdaptor

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "silverstripe/silverstripe-discoverer": "3.0.1",
-        "silverstripe/silverstripe-search-client-php": "dev-feature/roll-your-own as 0.0.8-alpha",
+        "silverstripe/silverstripe-discoverer": "^3.0.1",
+        "silverstripe/silverstripe-search-client-php": "^1",
         "guzzlehttp/guzzle": "^7.9",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.20"

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,10 @@
         "php": "^8.3",
         "silverstripe/framework": "^6",
         "silverstripe/silverstripe-discoverer": "3.0.1",
-        "silverstripe/silverstripe-search-client-php": "0.0.7-alpha",
-        "guzzlehttp/guzzle": "^7.9"
+        "silverstripe/silverstripe-search-client-php": "dev-feature/roll-your-own as 0.0.8-alpha",
+        "guzzlehttp/guzzle": "^7.9",
+        "php-http/client-common": "^2.7",
+        "php-http/discovery": "^1.20"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",

--- a/src/Processors/QuerySuggestionRequestProcessor.php
+++ b/src/Processors/QuerySuggestionRequestProcessor.php
@@ -4,7 +4,7 @@ namespace SilverStripe\DiscovererBifrost\Processors;
 
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Query\Suggestion;
-use Silverstripe\Search\Client\Model\QuerySuggestionRequest;
+use Silverstripe\Search\Client\Request\Search\QuerySuggestionRequest;
 
 class QuerySuggestionRequestProcessor
 {
@@ -13,8 +13,7 @@ class QuerySuggestionRequestProcessor
 
     public function getRequest(Suggestion $suggestion): QuerySuggestionRequest
     {
-        $request = new QuerySuggestionRequest();
-        $request->setQuery($suggestion->getQueryString());
+        $request = new QuerySuggestionRequest($suggestion->getQueryString());
 
         $limit = $suggestion->getLimit();
         $fields = $suggestion->getFields();

--- a/src/Processors/QuerySuggestionsProcessor.php
+++ b/src/Processors/QuerySuggestionsProcessor.php
@@ -6,7 +6,7 @@ use Exception;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Service\Results\Field;
 use SilverStripe\Discoverer\Service\Results\Suggestions;
-use Silverstripe\Search\Client\Model\QuerySuggestionResponse;
+use stdClass;
 
 class QuerySuggestionsProcessor
 {
@@ -16,13 +16,13 @@ class QuerySuggestionsProcessor
     /**
      * @throws Exception
      */
-    public function getProcessedSuggestions(Suggestions $suggestions, QuerySuggestionResponse $response): void
+    public function getProcessedSuggestions(Suggestions $suggestions, stdClass $response): void
     {
-        $results = $response->getResults() ?? [];
+        $results = $response->results ?? [];
 
         foreach ($results as $result) {
             $suggestions->addSuggestion(Field::create(
-                $result->getRaw() ?? null,
+                $result->raw ?? null,
             ));
         }
     }

--- a/src/Processors/SearchRequestProcessor.php
+++ b/src/Processors/SearchRequestProcessor.php
@@ -2,17 +2,17 @@
 
 namespace SilverStripe\DiscovererBifrost\Processors;
 
-use ArrayObject;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Query\Filter\Criteria;
 use SilverStripe\Discoverer\Query\Query;
-use Silverstripe\Search\Client\Model\Filters;
-use Silverstripe\Search\Client\Model\PaginationNoTotals;
-use Silverstripe\Search\Client\Model\SearchRequest;
-use Silverstripe\Search\Client\Model\SearchRequestResultField;
-use Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw;
-use Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet;
-use Silverstripe\Search\Client\Model\Tags;
+use Silverstripe\Search\Client\Model\Field\ResultField;
+use Silverstripe\Search\Client\Model\Field\ResultFieldRaw;
+use Silverstripe\Search\Client\Model\Field\ResultFieldSnippet;
+use Silverstripe\Search\Client\Model\Field\SearchFieldWeight;
+use Silverstripe\Search\Client\Model\Pagination;
+use Silverstripe\Search\Client\Model\Search\Filters;
+use Silverstripe\Search\Client\Model\Search\Tags;
+use Silverstripe\Search\Client\Request\Search\SearchRequest;
 
 class SearchRequestProcessor
 {
@@ -21,8 +21,7 @@ class SearchRequestProcessor
 
     public function getRequest(Query $query): SearchRequest
     {
-        $request = new SearchRequest();
-        $request->setQuery($query->getQueryString());
+        $request = new SearchRequest($query->getQueryString());
 
         $facets = $this->getFacetsFromQuery($query);
         $filters = $this->getFiltersFromQuery($query);
@@ -53,7 +52,7 @@ class SearchRequestProcessor
         }
 
         if ($sort) {
-            $request->setSort($sort);
+            $request->setSorts($sort);
         }
 
         if ($tags) {
@@ -63,7 +62,7 @@ class SearchRequestProcessor
         return $request;
     }
 
-    private function getFacetsFromQuery(Query $query): ?ArrayObject
+    private function getFacetsFromQuery(Query $query): ?array
     {
         if (!$query->getFacetCollection()->getFacets()) {
             return null;
@@ -104,7 +103,7 @@ class SearchRequestProcessor
         return $filters;
     }
 
-    private function getPaginationFromQuery(Query $query): ?PaginationNoTotals
+    private function getPaginationFromQuery(Query $query): ?Pagination
     {
         if (!$query->hasPagination()) {
             return null;
@@ -117,67 +116,55 @@ class SearchRequestProcessor
         // Bifröst uses page numbers instead of offset, so we need to convert. Note: Offset starts at 0
         $pageNum = (int) ceil($offset / $limit) + 1;
 
-        $pagination = new PaginationNoTotals();
-        $pagination->setSize($limit);
-        $pagination->setCurrent($pageNum);
-
-        return $pagination;
+        return new Pagination($pageNum, $limit);
     }
 
-    private function getResultFieldsFromQuery(Query $query): ?ArrayObject
+    /**
+     * @return array<string, ResultField>|null
+     */
+    private function getResultFieldsFromQuery(Query $query): ?array
     {
         if (!$query->getResultFields()) {
             return null;
         }
 
-        $resultFields = new ArrayObject();
+        $resultFields = [];
         // Ensure we include the default fields, to allow us to map these documents back to Silverstripe DataObjects
-        $resultFields['record_base_class'] = new SearchRequestResultField();
-        $resultFields['record_base_class']->setRaw(new SearchRequestResultFieldRaw());
-        $resultFields['record_id'] = new SearchRequestResultField();
-        $resultFields['record_id']->setRaw(new SearchRequestResultFieldRaw());
-        $resultFields['id'] = new SearchRequestResultField();
-        $resultFields['id']->setRaw(new SearchRequestResultFieldRaw());
+        $resultFields['record_base_class'] = (new ResultField())->setRaw(new ResultFieldRaw());
+        $resultFields['record_id'] = (new ResultField())->setRaw(new ResultFieldRaw());
+        $resultFields['id'] = (new ResultField())->setRaw(new ResultFieldRaw());
 
         foreach ($query->getResultFields() as $field) {
             $fieldName = $field->getFieldName();
             $fieldSize = $field->getLength();
-            $fieldType = $field->isFormatted()
-                ? new SearchRequestResultFieldSnippet()
-                : new SearchRequestResultFieldRaw();
 
             if (!isset($resultFields[$fieldName])) {
-                $resultFields[$fieldName] = new SearchRequestResultField();
+                $resultFields[$fieldName] = new ResultField();
             }
 
-            if ($fieldSize) {
-                $fieldType->setSize($fieldSize);
+            if ($field->isFormatted()) {
+                $resultFields[$fieldName]->setSnippet(new ResultFieldSnippet($fieldSize ?: null));
+            } else {
+                $resultFields[$fieldName]->setRaw(new ResultFieldRaw($fieldSize ?: null));
             }
-
-            $field->isFormatted()
-                ? $resultFields[$fieldName]->setSnippet($fieldType)
-                : $resultFields[$fieldName]->setRaw($fieldType);
         }
 
         return $resultFields;
     }
 
-    private function getSearchFieldsFromQuery(Query $query): ?ArrayObject
+    /**
+     * @return array<string, SearchFieldWeight>|null
+     */
+    private function getSearchFieldsFromQuery(Query $query): ?array
     {
         if (!$query->getSearchFields()) {
             return null;
         }
 
-        $searchFields = new ArrayObject();
+        $searchFields = [];
 
         foreach ($query->getSearchFields() as $fieldName => $weight) {
-            $searchFields[$fieldName] = new ArrayObject();
-
-            if (!$weight) {
-                continue;
-            }
-
-            $searchFields[$fieldName]['weight'] = $weight;
+            $searchFields[$fieldName] = new SearchFieldWeight($weight ?: null);
         }
 
         return $searchFields;
@@ -188,10 +175,7 @@ class SearchRequestProcessor
         $processedSort = [];
 
         foreach ($query->getSort() as $fieldName => $direction) {
-            $sort = new ArrayObject();
-            $sort[$fieldName] = strtolower($direction);
-
-            $processedSort[] = $sort;
+            $processedSort[] = [$fieldName => strtolower($direction)];
         }
 
         return $processedSort;
@@ -203,10 +187,7 @@ class SearchRequestProcessor
             return null;
         }
 
-        $processedTags = new Tags();
-        $processedTags->setTags($query->getTags());
-
-        return $processedTags;
+        return new Tags($query->getTags());
     }
 
 }

--- a/src/Processors/SearchRequestProcessor.php
+++ b/src/Processors/SearchRequestProcessor.php
@@ -12,6 +12,7 @@ use Silverstripe\Search\Client\Model\SearchRequest;
 use Silverstripe\Search\Client\Model\SearchRequestResultField;
 use Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw;
 use Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet;
+use Silverstripe\Search\Client\Model\Tags;
 
 class SearchRequestProcessor
 {
@@ -29,6 +30,7 @@ class SearchRequestProcessor
         $resultFields = $this->getResultFieldsFromQuery($query);
         $searchFields = $this->getSearchFieldsFromQuery($query);
         $sort = $this->getSortFromQuery($query);
+        $tags = $this->getTagsFromQuery($query);
 
         if ($facets) {
             $request->setFacets($facets);
@@ -52,6 +54,10 @@ class SearchRequestProcessor
 
         if ($sort) {
             $request->setSort($sort);
+        }
+
+        if ($tags) {
+            $request->setAnalytics($tags);
         }
 
         return $request;
@@ -189,6 +195,18 @@ class SearchRequestProcessor
         }
 
         return $processedSort;
+    }
+
+    private function getTagsFromQuery(Query $query): ?Tags
+    {
+        if (!$query->getTags()) {
+            return null;
+        }
+
+        $processedTags = new Tags();
+        $processedTags->setTags($query->getTags());
+
+        return $processedTags;
     }
 
 }

--- a/src/Processors/SpellingSuggestionRequestProcessor.php
+++ b/src/Processors/SpellingSuggestionRequestProcessor.php
@@ -4,7 +4,7 @@ namespace SilverStripe\DiscovererBifrost\Processors;
 
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Query\Suggestion;
-use Silverstripe\Search\Client\Model\SpellingSuggestionRequest;
+use Silverstripe\Search\Client\Request\Search\SpellingSuggestionRequest;
 
 class SpellingSuggestionRequestProcessor
 {
@@ -13,19 +13,14 @@ class SpellingSuggestionRequestProcessor
 
     public function getRequest(Suggestion $suggestion): SpellingSuggestionRequest
     {
-        $request = new SpellingSuggestionRequest();
-        $request->setQuery($suggestion->getQueryString());
+        $fields = $suggestion->getFields() ?? [];
+        $request = new SpellingSuggestionRequest($suggestion->getQueryString(), $fields);
         $request->setFormatted($suggestion->isFormatted());
 
         $limit = $suggestion->getLimit();
-        $fields = $suggestion->getFields();
 
         if ($limit) {
             $request->setSize($limit);
-        }
-
-        if ($fields) {
-            $request->setFields($fields);
         }
 
         return $request;

--- a/src/Processors/SpellingSuggestionsProcessor.php
+++ b/src/Processors/SpellingSuggestionsProcessor.php
@@ -6,7 +6,7 @@ use Exception;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Service\Results\Field;
 use SilverStripe\Discoverer\Service\Results\Suggestions;
-use Silverstripe\Search\Client\Model\SpellingSuggestionResponse;
+use stdClass;
 
 class SpellingSuggestionsProcessor
 {
@@ -16,14 +16,14 @@ class SpellingSuggestionsProcessor
     /**
      * @throws Exception
      */
-    public function getProcessedSuggestions(Suggestions $suggestions, SpellingSuggestionResponse $response): void
+    public function getProcessedSuggestions(Suggestions $suggestions, stdClass $response): void
     {
-        $results = $response->getResults() ?? [];
+        $results = $response->results ?? [];
 
         foreach ($results as $result) {
             $suggestions->addSuggestion(Field::create(
-                $result->getRaw() ?? null,
-                $result->getSnippet() ?? null,
+                $result->raw ?? null,
+                $result->snippet ?? null,
             ));
         }
     }

--- a/src/Query/Facet/FacetAdaptor.php
+++ b/src/Query/Facet/FacetAdaptor.php
@@ -2,25 +2,19 @@
 
 namespace SilverStripe\DiscovererBifrost\Query\Facet;
 
-use ArrayObject;
 use SilverStripe\Discoverer\Query\Facet\Facet;
 use SilverStripe\Discoverer\Query\Facet\FacetAdaptor as FacetAdaptorInterface;
 use SilverStripe\Discoverer\Query\Facet\FacetCollection;
+use Silverstripe\Search\Client\Model\Search\FacetRange;
+use Silverstripe\Search\Client\Model\Search\FacetRangeObject;
+use Silverstripe\Search\Client\Model\Search\FacetValue;
 
 class FacetAdaptor implements FacetAdaptorInterface
 {
 
-    public const string TYPE_VALUE = 'value';
-    public const string TYPE_RANGE = 'range';
-
-    private const array TYPE_CONVERSION = [
-        Facet::TYPE_VALUE => self::TYPE_VALUE,
-        Facet::TYPE_RANGE => self::TYPE_RANGE,
-    ];
-
     public function prepareFacets(FacetCollection $facetCollection): mixed
     {
-        $facets = new ArrayObject();
+        $facets = [];
 
         foreach ($facetCollection->getFacets() as $facet) {
             $fieldName = $facet->getFieldName();
@@ -35,32 +29,35 @@ class FacetAdaptor implements FacetAdaptorInterface
         return $facets;
     }
 
-    private function prepareFacet(Facet $facet): ArrayObject
+    private function prepareFacet(Facet $facet): FacetValue|FacetRange
     {
-        $preparedFacet = new ArrayObject();
-        $preparedFacet['type'] = self::TYPE_CONVERSION[$facet->getType()];
-
-        if ($facet->getName()) {
-            $preparedFacet['name'] = $facet->getName();
-        }
-
         if ($facet->getType() === Facet::TYPE_VALUE) {
+            $preparedFacet = new FacetValue();
+
+            if ($facet->getName()) {
+                $preparedFacet->setName($facet->getName());
+            }
+
             if ($facet->getLimit()) {
-                $preparedFacet['size'] = $facet->getLimit();
+                $preparedFacet->setSize($facet->getLimit());
             }
 
             return $preparedFacet;
         }
 
         $ranges = $this->prepareRanges($facet);
+        $preparedFacet = new FacetRange($ranges ?? []);
 
-        if ($ranges) {
-            $preparedFacet['ranges'] = $ranges;
+        if ($facet->getName()) {
+            $preparedFacet->setName($facet->getName());
         }
 
         return $preparedFacet;
     }
 
+    /**
+     * @return FacetRangeObject[]|null
+     */
     private function prepareRanges(Facet $facet): ?array
     {
         if (!$facet->getRanges()) {
@@ -70,28 +67,15 @@ class FacetAdaptor implements FacetAdaptorInterface
         $ranges = [];
 
         foreach ($facet->getRanges() as $range) {
-            $preparedRange = [];
             $from = $range->getFrom();
             $to = $range->getTo();
             $name = $range->getName();
 
-            if ($from) {
-                $preparedRange['from'] = $from;
-            }
-
-            if ($to) {
-                $preparedRange['to'] = $to;
-            }
-
-            if ($name) {
-                $preparedRange['name'] = $name;
-            }
-
-            if (count($preparedRange) === 0) {
+            if ($from === null && $to === null && $name === null) {
                 continue;
             }
 
-            $ranges[] = $preparedRange;
+            $ranges[] = new FacetRangeObject($from, $to, $name);
         }
 
         if (count($ranges) === 0) {

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
+
+use SilverStripe\Discoverer\Analytics\AnalyticsData;
+use SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor as ProcessAnalyticsAdaptorInterface;
+use Silverstripe\Search\Client\Request\Analytics\ClickRequest;
+use Throwable;
+
+class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAdaptorInterface
+{
+
+    /**
+     * General rule: We never want to break the search request being made for analytic click data. So, if something
+     * goes wrong, we will log and continue
+     */
+    public function process(AnalyticsData $analyticsData): void
+    {
+        try {
+            $indexName = $analyticsData->getIndexName();
+            $requestId = $analyticsData->getRequestId();
+            $documentId = $analyticsData->getDocumentId();
+
+            // Better safe than sorry, but these should be set if Analytics are enabled. If they aren't there (for
+            // whatever reason), then silently log
+            if (!$indexName || !$requestId || !$documentId) {
+                // Log the error without breaking the page ("warning" is the highest level we can log without changing
+                // the response code)
+                $this->getLogger()->warning(
+                    'Analytics data is missing required fields',
+                    [
+                        'indexName' => $indexName,
+                        'requestId' => $requestId,
+                        'documentId' => $documentId,
+                    ]
+                );
+
+                return;
+            }
+
+            $request = new ClickRequest((string) $requestId, (string) $documentId);
+
+            $response = $this->getClient()->clickPost($indexName, $request);
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode >= 500) {
+                // Log the error without breaking the page ("warning" is the highest level we can log without changing
+                // the response code)
+                $this->getLogger()->warning(
+                    sprintf('Analytics click request failed with status %d', $statusCode),
+                    [
+                        'responseBody' => (string) $response->getBody(),
+                    ]
+                );
+            }
+        } catch (Throwable $e) {
+            // Log the error without breaking the page ("warning" is the highest level we can log without changing
+            // the response code)
+            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
+        }
+    }
+
+}

--- a/src/Service/Adaptors/QuerySuggestionAdaptor.php
+++ b/src/Service/Adaptors/QuerySuggestionAdaptor.php
@@ -8,9 +8,6 @@ use SilverStripe\Discoverer\Service\Results\Suggestions;
 use SilverStripe\Discoverer\Service\SearchService;
 use SilverStripe\DiscovererBifrost\Processors\QuerySuggestionRequestProcessor;
 use SilverStripe\DiscovererBifrost\Processors\QuerySuggestionsProcessor;
-use Silverstripe\Search\Client\Exception\QuerySuggestionPostNotFoundException;
-use Silverstripe\Search\Client\Exception\QuerySuggestionPostUnprocessableEntityException;
-use Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException;
 use Throwable;
 
 class QuerySuggestionAdaptor extends BaseAdaptor implements QuerySuggestionAdaptorInterface
@@ -20,44 +17,42 @@ class QuerySuggestionAdaptor extends BaseAdaptor implements QuerySuggestionAdapt
     {
         try {
             $request = QuerySuggestionRequestProcessor::singleton()->getRequest($suggestion);
-            $response = $this->getClient()->querySuggestionPost(
+            $response = $this->getClient()->querySuggestion(
                 SearchService::singleton()->environmentizeIndex($indexSuffix),
                 $request
             );
 
-            $suggestions = Suggestions::create(200);
-            QuerySuggestionsProcessor::singleton()->getProcessedSuggestions($suggestions, $response);
-        } catch (QuerySuggestionPostNotFoundException | QuerySuggestionPostUnprocessableEntityException $e) {
-            // Log the error without breaking the page ("warning" is the highest level we can log without changing the
-            // client response to a 500)
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => (string) $e->getResponse()->getBody(),
-                ]
-            );
+            $statusCode = $response->getStatusCode();
+            $suggestions = Suggestions::create($statusCode);
 
-            $suggestions = Suggestions::create($e->getResponse()->getStatusCode());
-        } catch (UnexpectedStatusCodeException $e) {
-            // Log the error without breaking the page ("warning" is the highest level we can log without changing the
-            // client response to a 500)
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => $e->getMessage(),
-                ]
-            );
+            // Valid response; process and return
+            if ($statusCode >= 200 && $statusCode < 300) {
+                QuerySuggestionsProcessor::singleton()->getProcessedSuggestions(
+                    $suggestions,
+                    json_decode((string) $response->getBody())
+                );
 
-            $suggestions = Suggestions::create($e->getCode());
+                return $suggestions;
+            }
+
+            if ($statusCode >= 500) {
+                // Log the error without breaking the page ("warning" is the highest level we can log without changing
+                // the client response code)
+                $this->getLogger()->warning(
+                    sprintf('Query suggestion request failed with status %d', $statusCode),
+                    [
+                        'responseBody' => (string) $response->getBody(),
+                    ]
+                );
+            }
+
+            return $suggestions;
         } catch (Throwable $e) {
             // Log the error without breaking the page ("warning" is the highest level we can log without changing the
-            // client response to a 500)
+            // client response code)
             $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
-            $suggestions = Suggestions::create(500);
-        } finally {
-            return $suggestions;
+
+            return Suggestions::create(500);
         }
     }
 

--- a/src/Service/Adaptors/SearchAdaptor.php
+++ b/src/Service/Adaptors/SearchAdaptor.php
@@ -2,61 +2,57 @@
 
 namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
 
-use Exception;
 use SilverStripe\Discoverer\Query\Query;
 use SilverStripe\Discoverer\Service\Interfaces\SearchAdaptor as SearchAdaptorInterface;
 use SilverStripe\Discoverer\Service\Results\Results;
 use SilverStripe\Discoverer\Service\SearchService;
 use SilverStripe\DiscovererBifrost\Processors\SearchRequestProcessor;
 use SilverStripe\DiscovererBifrost\Processors\SearchResultsProcessor;
-use Silverstripe\Search\Client\Exception\SearchPostNotFoundException;
-use Silverstripe\Search\Client\Exception\SearchPostUnprocessableEntityException;
-use Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException;
-use stdClass;
 use Throwable;
 
 class SearchAdaptor extends BaseAdaptor implements SearchAdaptorInterface
 {
 
-    /**
-     * @throws Exception
-     */
     public function process(Query $query, string $indexSuffix): Results
     {
         try {
             $request = SearchRequestProcessor::singleton()->getRequest($query);
-            // searchPost() returns a stdClass() even though the typehint states otherwise
-            /** @var stdClass $response */
-            $response = $this->getClient()->searchPost(
+            $response = $this->getClient()->search(
                 SearchService::singleton()->environmentizeIndex($indexSuffix),
                 $request
             );
 
-            $results = Results::create(200, $query);
-            SearchResultsProcessor::singleton()->getProcessedResults($results, $response);
-        } catch (SearchPostNotFoundException|SearchPostUnprocessableEntityException $e) {
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => (string) $e->getResponse()->getBody(),
-                ]
-            );
-            $results = Results::create($e->getResponse()->getStatusCode(), $query);
-        } catch (UnexpectedStatusCodeException $e) {
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => $e->getMessage(),
-                ]
-            );
-            $results = Results::create($e->getCode(), $query);
-        } catch (Throwable $e) {
-            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
-            $results = Results::create(500, $query);
-        } finally {
+            $statusCode = $response->getStatusCode();
+            $results = Results::create($statusCode, $query);
+
+            // Valid response; process and return
+            if ($statusCode >= 200 && $statusCode < 300) {
+                SearchResultsProcessor::singleton()->getProcessedResults(
+                    $results,
+                    json_decode((string) $response->getBody())
+                );
+
+                return $results;
+            }
+
+            if ($statusCode >= 500) {
+                // Log the error without breaking the page ("warning" is the highest level we can log without changing
+                // the client response code)
+                $this->getLogger()->warning(
+                    sprintf('Search request failed with status %d', $statusCode),
+                    [
+                        'responseBody' => (string) $response->getBody(),
+                    ]
+                );
+            }
+
             return $results;
+        } catch (Throwable $e) {
+            // Log the error without breaking the page ("warning" is the highest level we can log without changing
+            // the client response code)
+            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
+
+            return Results::create(500, $query);
         }
     }
 

--- a/src/Service/Adaptors/SpellingSuggestionAdaptor.php
+++ b/src/Service/Adaptors/SpellingSuggestionAdaptor.php
@@ -8,9 +8,6 @@ use SilverStripe\Discoverer\Service\Results\Suggestions;
 use SilverStripe\Discoverer\Service\SearchService;
 use SilverStripe\DiscovererBifrost\Processors\SpellingSuggestionRequestProcessor;
 use SilverStripe\DiscovererBifrost\Processors\SpellingSuggestionsProcessor;
-use Silverstripe\Search\Client\Exception\SpellingSuggestionPostNotFoundException;
-use Silverstripe\Search\Client\Exception\SpellingSuggestionPostUnprocessableEntityException;
-use Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException;
 use Throwable;
 
 class SpellingSuggestionAdaptor extends BaseAdaptor implements SpellingSuggestionAdaptorInterface
@@ -20,36 +17,42 @@ class SpellingSuggestionAdaptor extends BaseAdaptor implements SpellingSuggestio
     {
         try {
             $request = SpellingSuggestionRequestProcessor::singleton()->getRequest($suggestion);
-            $response = $this->getClient()->spellingSuggestionPost(
+            $response = $this->getClient()->spellingSuggestion(
                 SearchService::singleton()->environmentizeIndex($indexSuffix),
                 $request
             );
 
-            $suggestions = Suggestions::create(200);
-            SpellingSuggestionsProcessor::singleton()->getProcessedSuggestions($suggestions, $response);
-        } catch (SpellingSuggestionPostNotFoundException | SpellingSuggestionPostUnprocessableEntityException $e) {
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => (string) $e->getResponse()->getBody(),
-                ]
-            );
-            $suggestions = Suggestions::create($e->getResponse()->getStatusCode());
-        } catch (UnexpectedStatusCodeException $e) {
-            $this->getLogger()->warning(
-                $e->getMessage(),
-                [
-                    'exception' => $e,
-                    'responseBody' => $e->getMessage(),
-                ]
-            );
-            $suggestions = Suggestions::create($e->getCode());
-        } catch (Throwable $e) {
-            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
-            $suggestions = Suggestions::create(500);
-        } finally {
+            $statusCode = $response->getStatusCode();
+            $suggestions = Suggestions::create($statusCode);
+
+            // Valid response; process and return
+            if ($statusCode >= 200 && $statusCode < 300) {
+                SpellingSuggestionsProcessor::singleton()->getProcessedSuggestions(
+                    $suggestions,
+                    json_decode((string) $response->getBody())
+                );
+
+                return $suggestions;
+            }
+
+            if ($statusCode >= 500) {
+                // Log the error without breaking the page ("warning" is the highest level we can log without changing
+                // the client response code)
+                $this->getLogger()->warning(
+                    sprintf('Spelling suggestion request failed with status %d', $statusCode),
+                    [
+                        'responseBody' => (string) $response->getBody(),
+                    ]
+                );
+            }
+
             return $suggestions;
+        } catch (Throwable $e) {
+            // Log the error without breaking the page ("warning" is the highest level we can log without changing
+            // the client response code)
+            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
+
+            return Suggestions::create(500);
         }
     }
 

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -8,6 +8,7 @@ use Http\Client\Common\Plugin\AddPathPlugin;
 use Http\Client\Common\Plugin\HeaderAppendPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use SilverStripe\Core\Injector\Factory;
 use Silverstripe\Search\Client\Client;
 
@@ -48,14 +49,14 @@ class ClientFactory implements Factory
             ]),
         ];
 
-        if ($httpClient) {
-            // If a desired HTTP Client has been defined and instantiated in config (@see config.yml) then we'll
-            // apply the plugins and return it here
-            return Client::create(new PluginClient($httpClient, $plugins));
-        }
+        // If no HTTP client was provided, discover one via PSR-18
+        $httpClient ??= Psr18ClientDiscovery::find();
 
-        // If no client is defined, then it will be left up to PSR-18 "discovery"
-        return Client::create(null, $plugins);
+        return new Client(
+            new PluginClient($httpClient, $plugins),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+        );
     }
 
 }

--- a/tests/Processors/SearchRequestProcessorTest.php
+++ b/tests/Processors/SearchRequestProcessorTest.php
@@ -23,6 +23,7 @@ use Silverstripe\Search\Client\Model\Filters;
 use Silverstripe\Search\Client\Model\PaginationNoTotals;
 use Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw;
 use Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet;
+use Silverstripe\Search\Client\Model\Tags;
 use stdClass;
 
 class SearchRequestProcessorTest extends SapphireTest
@@ -273,6 +274,31 @@ class SearchRequestProcessorTest extends SapphireTest
         );
     }
 
+    public function testGetTagsFromQuery(): void
+    {
+        $query = Query::create();
+
+        /** @see SearchRequestProcessor::getSortFromQuery() */
+        $reflectionMethod = new ReflectionMethod(SearchRequestProcessor::class, 'getTagsFromQuery');
+        $reflectionMethod->setAccessible(true);
+
+        // First test that the value is null if no sorts are set
+        $this->assertNull($reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query));
+
+        // Add tags and retest
+        $query->addTag('tag1');
+        $query->addTag('tag2');
+
+        $expected = [
+            'tag1',
+            'tag2',
+        ];
+        $tags = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
+
+        $this->assertInstanceOf(Tags::class, $tags);
+        $this->assertEqualsCanonicalizing($expected, $tags->getTags());
+    }
+
     public function testGetQueryParams(): void
     {
         $query = Query::create('search string');
@@ -288,6 +314,7 @@ class SearchRequestProcessorTest extends SapphireTest
         $query->addSort('field3');
         $query->filter('field1', 'value1', Criterion::EQUAL);
         $query->setPagination(10, 20);
+        $query->addTag('tag1');
 
         // This test is really just checking that each method was invoked, as the individual methods are all tested
         // in depth above
@@ -299,6 +326,7 @@ class SearchRequestProcessorTest extends SapphireTest
         $this->assertInstanceOf(ArrayObject::class, $request->getResultFields());
         $this->assertInstanceOf(ArrayObject::class, $request->getSearchFields());
         $this->assertInstanceOf(PaginationNoTotals::class, $request->getPage());
+        $this->assertInstanceOf(Tags::class, $request->getAnalytics());
         $this->assertIsArray($request->getSort());
     }
 

--- a/tests/Processors/SearchRequestProcessorTest.php
+++ b/tests/Processors/SearchRequestProcessorTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\DiscovererBifrost\Tests\Processors;
 
-use ArrayObject;
 use ReflectionMethod;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
@@ -19,12 +18,13 @@ use SilverStripe\DiscovererBifrost\Query\Filter\CriteriaAdaptor;
 use SilverStripe\DiscovererBifrost\Query\Filter\CriterionAdaptor;
 use SilverStripe\DiscovererBifrost\Tests\Query\Facet\FacetAdaptorTest;
 use SilverStripe\DiscovererBifrost\Tests\Query\Filter\CriteriaAdaptorTest;
-use Silverstripe\Search\Client\Model\Filters;
-use Silverstripe\Search\Client\Model\PaginationNoTotals;
-use Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw;
-use Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet;
-use Silverstripe\Search\Client\Model\Tags;
-use stdClass;
+use Silverstripe\Search\Client\Model\Field\ResultField;
+use Silverstripe\Search\Client\Model\Field\ResultFieldRaw;
+use Silverstripe\Search\Client\Model\Field\ResultFieldSnippet;
+use Silverstripe\Search\Client\Model\Field\SearchFieldWeight;
+use Silverstripe\Search\Client\Model\Pagination;
+use Silverstripe\Search\Client\Model\Search\Filters;
+use Silverstripe\Search\Client\Model\Search\Tags;
 
 class SearchRequestProcessorTest extends SapphireTest
 {
@@ -59,9 +59,9 @@ class SearchRequestProcessorTest extends SapphireTest
         $query->addFacet($facetOne);
         $query->addFacet($facetTwo);
 
-        /** @var ArrayObject $facets */
         $facets = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
 
+        $this->assertIsArray($facets);
         $this->assertArrayHasKey('fieldName1', $facets);
         $this->assertArrayHasKey('fieldName2', $facets);
     }
@@ -129,7 +129,7 @@ class SearchRequestProcessorTest extends SapphireTest
         // Set pagination and retest
         $query->setPagination(10, 0);
 
-        /** @var PaginationNoTotals $pagination */
+        /** @var Pagination $pagination */
         $pagination = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
 
         $this->assertEquals(10, $pagination->getSize());
@@ -138,7 +138,7 @@ class SearchRequestProcessorTest extends SapphireTest
         // Set pagination and retest. Note: offset starts at 0, so an offset of 20 is page 3, not page 2
         $query->setPagination(10, 20);
 
-        /** @var PaginationNoTotals $pagination */
+        /** @var Pagination $pagination */
         $pagination = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
 
         $this->assertEquals(10, $pagination->getSize());
@@ -164,51 +164,40 @@ class SearchRequestProcessorTest extends SapphireTest
         $query->addResultField('field4', 100);
         $query->addResultField('field4', 20, true);
 
-        /** @var ArrayObject $resultsFields */
+        /** @var array<string, ResultField> $resultsFields */
         $resultsFields = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
 
         // Check that we have our two default result fields
         $this->assertArrayHasKey('record_base_class', $resultsFields);
         $this->assertArrayHasKey('record_id', $resultsFields);
         // Check that each of those default fields has a "raw" field
-        $this->assertTrue($resultsFields['record_base_class']->isInitialized('raw'));
-        $this->assertTrue($resultsFields['record_id']->isInitialized('raw'));
-        $this->assertInstanceOf(SearchRequestResultFieldRaw::class, $resultsFields['record_base_class']->getRaw());
-        $this->assertInstanceOf(SearchRequestResultFieldRaw::class, $resultsFields['record_id']->getRaw());
+        $this->assertInstanceOf(ResultFieldRaw::class, $resultsFields['record_base_class']->getRaw());
+        $this->assertInstanceOf(ResultFieldRaw::class, $resultsFields['record_id']->getRaw());
         // Check our custom result fields
         $this->assertArrayHasKey('field1', $resultsFields);
         $this->assertArrayHasKey('field2', $resultsFields);
         $this->assertArrayHasKey('field3', $resultsFields);
         $this->assertArrayHasKey('field4', $resultsFields);
 
-        // No snippet defined
-        $this->assertFalse($resultsFields['field1']->isInitialized('snippet'));
-        // Raw should be defined
-        $this->assertInstanceOf(SearchRequestResultFieldRaw::class, $resultsFields['field1']->getRaw());
-        // But raw.size was not defined
-        $this->assertFalse($resultsFields['field1']->getRaw()->isInitialized('size'));
+        // field1: No snippet defined, raw should be defined but raw.size was not defined
+        $this->assertNull($resultsFields['field1']->getSnippet());
+        $this->assertInstanceOf(ResultFieldRaw::class, $resultsFields['field1']->getRaw());
+        $this->assertNull($resultsFields['field1']->getRaw()->getSize());
 
-        // No raw defined
-        $this->assertFalse($resultsFields['field2']->isInitialized('raw'));
-        // Snippet should be defined
-        $this->assertInstanceOf(SearchRequestResultFieldSnippet::class, $resultsFields['field2']->getSnippet());
-        // But snippet.size was not defined
-        $this->assertFalse($resultsFields['field2']->getSnippet()->isInitialized('size'));
+        // field2: No raw defined, snippet should be defined but snippet.size was not defined
+        $this->assertNull($resultsFields['field2']->getRaw());
+        $this->assertInstanceOf(ResultFieldSnippet::class, $resultsFields['field2']->getSnippet());
+        $this->assertNull($resultsFields['field2']->getSnippet()->getSize());
 
-        // No snippet defined
-        $this->assertFalse($resultsFields['field3']->isInitialized('snippet'));
-        // Raw should be defined
-        $this->assertInstanceOf(SearchRequestResultFieldRaw::class, $resultsFields['field3']->getRaw());
-        // And raw.size was defined
+        // field3: No snippet defined, raw should be defined and raw.size was defined
+        $this->assertNull($resultsFields['field3']->getSnippet());
+        $this->assertInstanceOf(ResultFieldRaw::class, $resultsFields['field3']->getRaw());
         $this->assertEquals(10, $resultsFields['field3']->getRaw()->getSize());
 
-        // Raw should be defined
-        $this->assertInstanceOf(SearchRequestResultFieldRaw::class, $resultsFields['field4']->getRaw());
-        // And raw.size was defined
+        // field4: Both raw and snippet should be defined with sizes
+        $this->assertInstanceOf(ResultFieldRaw::class, $resultsFields['field4']->getRaw());
         $this->assertEquals(100, $resultsFields['field4']->getRaw()->getSize());
-        // Snippet should be defined
-        $this->assertInstanceOf(SearchRequestResultFieldSnippet::class, $resultsFields['field4']->getSnippet());
-        // And snippet.size was defined
+        $this->assertInstanceOf(ResultFieldSnippet::class, $resultsFields['field4']->getSnippet());
         $this->assertEquals(20, $resultsFields['field4']->getSnippet()->getSize());
     }
 
@@ -229,18 +218,17 @@ class SearchRequestProcessorTest extends SapphireTest
         // Weight added
         $query->addSearchField('field2', 2);
 
-        /** @var ArrayObject $searchFields */
+        /** @var array<string, SearchFieldWeight> $searchFields */
         $searchFields = $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query);
 
         $this->assertArrayHasKey('field1', $searchFields);
         $this->assertArrayHasKey('field2', $searchFields);
 
-        $fieldOneExpected = new ArrayObject();
-        $fieldTwoExpected = new ArrayObject();
-        $fieldTwoExpected['weight'] = 2;
+        $this->assertInstanceOf(SearchFieldWeight::class, $searchFields['field1']);
+        $this->assertNull($searchFields['field1']->getWeight());
 
-        $this->assertEquals($fieldOneExpected, $searchFields['field1']);
-        $this->assertEquals($fieldTwoExpected, $searchFields['field2']);
+        $this->assertInstanceOf(SearchFieldWeight::class, $searchFields['field2']);
+        $this->assertEquals(2, $searchFields['field2']->getWeight());
     }
 
     public function testGetSortFromQuery(): void
@@ -251,21 +239,16 @@ class SearchRequestProcessorTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod(SearchRequestProcessor::class, 'getSortFromQuery');
         $reflectionMethod->setAccessible(true);
 
-        // First test that the value is null if no sorts are set
+        // First test that the value is empty if no sorts are set
         $this->assertEquals([], $reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query));
 
         // Add sorts and retest
         $query->addSort('field1');
         $query->addSort('field2', Query::SORT_DESC);
 
-        $sortOne = new ArrayObject();
-        $sortOne['field1'] = 'asc';
-        $sortTwo = new ArrayObject();
-        $sortTwo['field2'] = 'desc';
-
         $expected = [
-            $sortOne,
-            $sortTwo,
+            ['field1' => 'asc'],
+            ['field2' => 'desc'],
         ];
 
         $this->assertEqualsCanonicalizing(
@@ -278,11 +261,11 @@ class SearchRequestProcessorTest extends SapphireTest
     {
         $query = Query::create();
 
-        /** @see SearchRequestProcessor::getSortFromQuery() */
+        /** @see SearchRequestProcessor::getTagsFromQuery() */
         $reflectionMethod = new ReflectionMethod(SearchRequestProcessor::class, 'getTagsFromQuery');
         $reflectionMethod->setAccessible(true);
 
-        // First test that the value is null if no sorts are set
+        // First test that the value is null if no tags are set
         $this->assertNull($reflectionMethod->invoke(SearchRequestProcessor::singleton(), $query));
 
         // Add tags and retest
@@ -321,13 +304,13 @@ class SearchRequestProcessorTest extends SapphireTest
         $request = SearchRequestProcessor::singleton()->getRequest($query);
 
         $this->assertEquals('search string', $request->getQuery());
-        $this->assertInstanceOf(ArrayObject::class, $request->getFacets());
+        $this->assertIsArray($request->getFacets());
         $this->assertInstanceOf(Filters::class, $request->getFilters());
-        $this->assertInstanceOf(ArrayObject::class, $request->getResultFields());
-        $this->assertInstanceOf(ArrayObject::class, $request->getSearchFields());
-        $this->assertInstanceOf(PaginationNoTotals::class, $request->getPage());
+        $this->assertIsArray($request->getResultFields());
+        $this->assertIsArray($request->getSearchFields());
+        $this->assertInstanceOf(Pagination::class, $request->getPage());
         $this->assertInstanceOf(Tags::class, $request->getAnalytics());
-        $this->assertIsArray($request->getSort());
+        $this->assertIsArray($request->getSorts());
     }
 
     protected function setUp(): void

--- a/tests/Query/Facet/FacetAdaptorTest.php
+++ b/tests/Query/Facet/FacetAdaptorTest.php
@@ -2,13 +2,14 @@
 
 namespace SilverStripe\DiscovererBifrost\Tests\Query\Facet;
 
-use ArrayObject;
-use Elastic\EnterpriseSearch\AppSearch\Schema\SimpleObject;
 use ReflectionMethod;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Discoverer\Query\Facet\Facet;
 use SilverStripe\Discoverer\Query\Facet\FacetCollection;
 use SilverStripe\DiscovererBifrost\Query\Facet\FacetAdaptor;
+use Silverstripe\Search\Client\Model\Search\FacetRange;
+use Silverstripe\Search\Client\Model\Search\FacetRangeObject;
+use Silverstripe\Search\Client\Model\Search\FacetValue;
 
 class FacetAdaptorTest extends SapphireTest
 {
@@ -24,28 +25,31 @@ class FacetAdaptorTest extends SapphireTest
         $facet->addRange(to: 4);
         $facet->addRange(name: 'test2');
 
-        $expected = [
-            [
-                'from' => 1,
-                'to' => 2,
-                'name' => 'test1',
-            ],
-            [
-                'from' => 3,
-            ],
-            [
-                'to' => 4,
-            ],
-            [
-                'name' => 'test2',
-            ],
-        ];
-
         /** @see FacetAdaptor::prepareRanges() */
         $reflectionMethod = new ReflectionMethod($adaptor, 'prepareRanges');
         $reflectionMethod->setAccessible(true);
 
-        $this->assertEqualsCanonicalizing($expected, $reflectionMethod->invoke($adaptor, $facet));
+        /** @var FacetRangeObject[] $ranges */
+        $ranges = $reflectionMethod->invoke($adaptor, $facet);
+
+        $this->assertCount(4, $ranges);
+
+        $this->assertInstanceOf(FacetRangeObject::class, $ranges[0]);
+        $this->assertEquals(1, $ranges[0]->getFrom());
+        $this->assertEquals(2, $ranges[0]->getTo());
+        $this->assertEquals('test1', $ranges[0]->getName());
+
+        $this->assertEquals(3, $ranges[1]->getFrom());
+        $this->assertNull($ranges[1]->getTo());
+        $this->assertNull($ranges[1]->getName());
+
+        $this->assertNull($ranges[2]->getFrom());
+        $this->assertEquals(4, $ranges[2]->getTo());
+        $this->assertNull($ranges[2]->getName());
+
+        $this->assertNull($ranges[3]->getFrom());
+        $this->assertNull($ranges[3]->getTo());
+        $this->assertEquals('test2', $ranges[3]->getName());
     }
 
     public function testPrepareRangesNoRange(): void
@@ -92,14 +96,13 @@ class FacetAdaptorTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod($adaptor, 'prepareFacet');
         $reflectionMethod->setAccessible(true);
 
-        $expected = [
-            'type' => FacetAdaptor::TYPE_VALUE,
-            'name' => 'facetName1',
-            'size' => 3,
-        ];
-        $expected = new ArrayObject($expected);
+        /** @var FacetValue $result */
+        $result = $reflectionMethod->invoke($adaptor, $facet);
 
-        $this->assertEqualsCanonicalizing($expected, $reflectionMethod->invoke($adaptor, $facet));
+        $this->assertInstanceOf(FacetValue::class, $result);
+        $this->assertSame('value', $result->getType());
+        $this->assertSame('facetName1', $result->getName());
+        $this->assertSame(3, $result->getSize());
     }
 
     public function testPrepareFacetRange(): void
@@ -115,20 +118,14 @@ class FacetAdaptorTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod($adaptor, 'prepareFacet');
         $reflectionMethod->setAccessible(true);
 
-        $expected = [
-            'type' => FacetAdaptor::TYPE_RANGE,
-            'name' => 'facetName1',
-            'ranges' => [
-                [
-                    'from' => 1,
-                    'to' => 2,
-                    'name' => 'test1',
-                ],
-            ],
-        ];
-        $expected = new ArrayObject($expected);
+        /** @var FacetRange $result */
+        $result = $reflectionMethod->invoke($adaptor, $facet);
 
-        $this->assertEqualsCanonicalizing($expected, $reflectionMethod->invoke($adaptor, $facet));
+        $this->assertInstanceOf(FacetRange::class, $result);
+        $this->assertSame('range', $result->getType());
+        $this->assertSame('facetName1', $result->getName());
+        $this->assertCount(1, $result->getRanges());
+        $this->assertInstanceOf(FacetRangeObject::class, $result->getRanges()[0]);
     }
 
     public function testPrepareFacets(): void
@@ -153,15 +150,15 @@ class FacetAdaptorTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod($adaptor, 'prepareFacets');
         $reflectionMethod->setAccessible(true);
 
-        /** @var ArrayObject $simpleObject */
-        $simpleObject = $reflectionMethod->invoke($adaptor, $facetCollection);
+        $result = $reflectionMethod->invoke($adaptor, $facetCollection);
 
+        $this->assertIsArray($result);
         // Check that we have the expected properties
-        $this->assertArrayHasKey('fieldName1', $simpleObject);
-        $this->assertArrayHasKey('fieldName2', $simpleObject);
+        $this->assertArrayHasKey('fieldName1', $result);
+        $this->assertArrayHasKey('fieldName2', $result);
         // And that those properties have the expected number of facet records
-        $this->assertCount(2, $simpleObject['fieldName1']);
-        $this->assertCount(1, $simpleObject['fieldName2']);
+        $this->assertCount(2, $result['fieldName1']);
+        $this->assertCount(1, $result['fieldName2']);
     }
 
 }

--- a/tests/Service/Adaptors/SearchAdaptorTest.php
+++ b/tests/Service/Adaptors/SearchAdaptorTest.php
@@ -12,13 +12,11 @@ use Http\Client\Common\Plugin\HeaderAppendPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Log\LoggerInterface;
-use ReflectionMethod;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Discoverer\Query\Query;
 use SilverStripe\Discoverer\Service\SearchService;
-use SilverStripe\DiscovererBifrost\Service\Adaptors\SearchAdaptor;
 use SilverStripe\DiscovererBifrost\Tests\Logger\QuietLogger;
 use Silverstripe\Search\Client\Client;
 use stdClass;
@@ -91,7 +89,11 @@ class SearchAdaptorTest extends SapphireTest
             ]),
         ];
 
-        $client = Client::create(new PluginClient($httpClient, $plugins));
+        $client = new Client(
+            new PluginClient($httpClient, $plugins),
+            Psr17FactoryDiscovery::findRequestFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+        );
 
         Injector::inst()->registerService($client, Client::class . '.searchClient');
         // Add our quiet logger, so that our API calls don't create any noise in our test report


### PR DESCRIPTION
## Updated Client

Relies on the changes here: https://github.com/silverstripeltd/silverstripe-search-client-php/pull/7

We'll want to update our composer dependency once the above is merged and tagged.

## Analytics

First was to add support for query `tags` back in (we might have removed it when we removed Analytics in general). Technically doesn't require any upstream changes.

Secondly (and more importantly) this also adds back the adaptor for Analytic Click events. This **does** require some upstream changes - IE the API to support Analytic Click events again.