### PR TITLE
AOS-591: Pass query precision through to the Bifrost SearchRequest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "silverstripe/silverstripe-discoverer": "^3.0.1",
-        "silverstripe/silverstripe-search-client-php": "^1",
+        "silverstripe/silverstripe-discoverer": "^3.1",
+        "silverstripe/silverstripe-search-client-php": "^1.1",
         "guzzlehttp/guzzle": "^7.9",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.20"
@@ -54,7 +54,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-main": "3.0.x-dev"
+            "dev-main": "3.2.x-dev"
         }
     }
 }

--- a/src/Processors/SearchRequestProcessor.php
+++ b/src/Processors/SearchRequestProcessor.php
@@ -59,6 +59,11 @@ class SearchRequestProcessor
             $request->setAnalytics($tags);
         }
 
+        // When null, the engine's configured (dashboard) precision is used
+        if ($query->getPrecision() !== null) {
+            $request->setPrecision($query->getPrecision());
+        }
+
         return $request;
     }
 

--- a/tests/Processors/SearchRequestProcessorTest.php
+++ b/tests/Processors/SearchRequestProcessorTest.php
@@ -282,6 +282,26 @@ class SearchRequestProcessorTest extends SapphireTest
         $this->assertEqualsCanonicalizing($expected, $tags->getTags());
     }
 
+    public function testPrecisionIsPassedThroughWhenSet(): void
+    {
+        $query = Query::create('search string');
+        $query->setPrecision(10);
+
+        $request = SearchRequestProcessor::singleton()->getRequest($query);
+
+        $this->assertEquals(10, $request->getPrecision());
+    }
+
+    public function testPrecisionIsOmittedWhenNotSet(): void
+    {
+        $query = Query::create('search string');
+
+        $request = SearchRequestProcessor::singleton()->getRequest($query);
+
+        // Null lets the engine use its configured (dashboard) precision
+        $this->assertNull($request->getPrecision());
+    }
+
     public function testGetQueryParams(): void
     {
         $query = Query::create('search string');
@@ -298,6 +318,7 @@ class SearchRequestProcessorTest extends SapphireTest
         $query->filter('field1', 'value1', Criterion::EQUAL);
         $query->setPagination(10, 20);
         $query->addTag('tag1');
+        $query->setPrecision(7);
 
         // This test is really just checking that each method was invoked, as the individual methods are all tested
         // in depth above
@@ -311,6 +332,7 @@ class SearchRequestProcessorTest extends SapphireTest
         $this->assertInstanceOf(Pagination::class, $request->getPage());
         $this->assertInstanceOf(Tags::class, $request->getAnalytics());
         $this->assertIsArray($request->getSorts());
+        $this->assertEquals(7, $request->getPrecision());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## What

Maps `Query::getPrecision()` onto `SearchRequest::setPrecision()` in `SearchRequestProcessor`, so a per-query precision override reaches the Bifröst API. When the query precision is `null` it is omitted and the engine's dashboard-configured precision is used.

## Why

Completes the query-time precision chain: application → Discoverer `Query` → Bifröst `SearchRequest` → API. Part of AOS-591.

## Depends on

- silverstripeltd/silverstripe-discoverer-bifrost requires the new APIs from:
  - silverstripe-search-client-php#8 (`SearchRequest::setPrecision`)
  - silverstripe-discoverer (`Query::getPrecision`)

  Merge/release those first.

## Tests

- Added `testPrecisionIsPassedThroughWhenSet`, `testPrecisionIsOmittedWhenNotSet`, and extended `testGetQueryParams` in `SearchRequestProcessorTest`.
- `php -l` clean. Full suite needs the dependency releases + a DB (CI).
