### PR TITLE
Click analytics follow-ups: fix CI lint, avoid the ClickPost BC break, widen error logging, add a test

### DIFF
--- a/_config/requests.yml
+++ b/_config/requests.yml
@@ -6,3 +6,5 @@ Only:
 SilverStripe\Core\Injector\Injector:
   Elastic\EnterpriseSearch\AppSearch\Request\Search:
     class: SilverStripe\DiscovererBifrost\Service\Requests\Search
+  Elastic\EnterpriseSearch\AppSearch\Request\LogClickthrough:
+    class: SilverStripe\DiscovererBifrost\Service\Requests\ClickPost

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -73,6 +73,8 @@
         <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
         <!-- Array type hint syntax is very useful -->
         <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+        <!-- Typed class constants are PHP 8.3+, and this module still supports PHP 8.1 -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint.MissingNativeTypeHint"/>
         <!-- Allow private static -->
         <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty"/>
         <!-- Even if you strictly type, there are other reasons to add a DocComment (EG: to add @codeCoverageIgnore -->
@@ -151,15 +153,22 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
             <property name="searchAnnotations" type="bool" value="true"/>
-            <property name="ignoredAnnotationNames" type="array" value="@config"/>
+            <property name="ignoredAnnotationNames" type="array">
+                <element value="@config"/>
+            </property>
         </properties>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <!-- Set the root namespace for our src dir and phpunit dir. Please change these as required -->
-            <property name="rootNamespaces" type="array" value="src=>SilverStripe\DiscovererBifrost,tests=>SilverStripe\DiscovererBifrost\Tests"/>
-            <property name="ignoredNamespaces" type="array" value="Slevomat\Services"/>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="SilverStripe\DiscovererBifrost"/>
+                <element key="tests" value="SilverStripe\DiscovererBifrost\Tests"/>
+            </property>
+            <property name="ignoredNamespaces" type="array">
+                <element value="Slevomat\Services"/>
+            </property>
         </properties>
     </rule>
 

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
 
+use Elastic\EnterpriseSearch\AppSearch\Schema\ClickParams;
 use Elastic\EnterpriseSearch\Client;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Injector\Injector;
@@ -43,7 +44,14 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
                 return;
             }
 
-            $request = ClickPost::create($engineName, (string) $requestId, (string) $documentId);
+            $params = Injector::inst()->create(
+                ClickParams::class,
+                (string) $analyticsData->getQueryString(),
+                (string) $documentId
+            );
+            $params->request_id = (string) $requestId;
+
+            $request = ClickPost::create($engineName, $params);
 
             $response = $this->getSearchClient()->appSearch()->getTransport()->sendRequest($request->getRequest());
             $statusCode = $response->getStatusCode();

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -3,8 +3,6 @@
 namespace SilverStripe\DiscovererBifrost\Service\Adaptors;
 
 use Elastic\EnterpriseSearch\AppSearch\Schema\ClickParams;
-use Elastic\EnterpriseSearch\Client;
-use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Discoverer\Analytics\AnalyticsData;
 use SilverStripe\Discoverer\Service\Interfaces\ProcessAnalyticsAdaptor as ProcessAnalyticsAdaptorInterface;
@@ -32,7 +30,7 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
             if (!$engineName || !$requestId || !$documentId) {
                 // Log the error without breaking the page ("warning" is the highest level we can log without changing
                 // the response code)
-                $this->logWarning(
+                $this->getLogger()->warning(
                     'Analytics data is missing required fields',
                     [
                         'engineName' => $engineName,
@@ -53,7 +51,7 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
 
             $request = ClickPost::create($engineName, $params);
 
-            $response = $this->getSearchClient()->appSearch()->getTransport()->sendRequest($request->getRequest());
+            $response = $this->getClient()->appSearch()->getTransport()->sendRequest($request->getRequest());
             $statusCode = $response->getStatusCode();
 
             // Report every unsuccessful response, not just server errors. A query API key without the analytics_click
@@ -62,7 +60,7 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
             if ($statusCode < 200 || $statusCode >= 300) {
                 // Log the error without breaking the page ("warning" is the highest level we can log without changing
                 // the response code)
-                $this->logWarning(
+                $this->getLogger()->warning(
                     sprintf('Analytics click request failed with status %d', $statusCode),
                     [
                         'responseBody' => (string) $response->getBody(),
@@ -72,33 +70,7 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
         } catch (Throwable $e) {
             // Log the error without breaking the page ("warning" is the highest level we can log without changing
             // the response code)
-            $this->logWarning($e->getMessage(), ['exception' => $e]);
-        }
-    }
-
-    /**
-     * The middleware that reaches this adaptor runs on every request, including ones where this object was built
-     * without its BaseAdaptor dependencies (a config manifest still holding an older version of this class does it).
-     * Fall back to the service directly rather than calling a method on null, and let an unresolvable service throw
-     * so that process() can log why
-     */
-    private function getSearchClient(): Client
-    {
-        return $this->getClient() ?? Injector::inst()->get(Client::class . '.searchClient');
-    }
-
-    /**
-     * Analytics must never break the page it was collected on, so this has to hold up even when there is no logger to
-     * report to - see getSearchClient() for how that happens
-     */
-    private function logWarning(string $message, array $context = []): void
-    {
-        try {
-            $logger = $this->getLogger() ?? Injector::inst()->get(LoggerInterface::class . '.errorhandler');
-
-            $logger->warning($message, $context);
-        } catch (Throwable) {
-            // There is nowhere left to report this
+            $this->getLogger()->warning($e->getMessage(), ['exception' => $e]);
         }
     }
 

--- a/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
+++ b/src/Service/Adaptors/ProcessAnalyticsAdaptor.php
@@ -56,7 +56,10 @@ class ProcessAnalyticsAdaptor extends BaseAdaptor implements ProcessAnalyticsAda
             $response = $this->getSearchClient()->appSearch()->getTransport()->sendRequest($request->getRequest());
             $statusCode = $response->getStatusCode();
 
-            if ($statusCode >= 500) {
+            // Report every unsuccessful response, not just server errors. A query API key without the analytics_click
+            // permission, or an engine the key cannot reach, comes back as a 4xx, and those are exactly the
+            // misconfigurations we want to see rather than silently drop
+            if ($statusCode < 200 || $statusCode >= 300) {
                 // Log the error without breaking the page ("warning" is the highest level we can log without changing
                 // the response code)
                 $this->logWarning(

--- a/src/Service/Requests/ClickPost.php
+++ b/src/Service/Requests/ClickPost.php
@@ -2,27 +2,35 @@
 
 namespace SilverStripe\DiscovererBifrost\Service\Requests;
 
-use Elastic\EnterpriseSearch\Request\Request;
+use Elastic\EnterpriseSearch\AppSearch\Request\LogClickthrough as AppSearchLogClickthrough;
+use Elastic\EnterpriseSearch\AppSearch\Schema\ClickParams;
 use SilverStripe\Core\Injector\Injectable;
 
-/**
- * Bifröst expects only the request and document IDs, so we build the body ourselves rather than extending Elastic's
- * LogClickthrough (whose ClickParams schema also carries a query string and tags)
- */
-class ClickPost extends Request
+class ClickPost extends AppSearchLogClickthrough
 {
 
     use Injectable;
 
-    public function __construct(string $engineName, string $requestId, string $documentId)
+    public function __construct(string $engineName, ?ClickParams $params = null)
     {
-        $this->method = 'POST';
-        $this->path = sprintf('/api/v1/%s/click', $engineName);
-        $this->headers['Content-Type'] = 'application/json';
-        $this->body = [
-            'request_id' => $requestId,
-            'document_id' => $documentId,
-        ];
+        parent::__construct($engineName, $params);
+
+        $this->path = sprintf('/api/v1/%s/click', urlencode($engineName));
+
+        // Bifröst accepts only the request and document IDs, so we narrow the body rather than sending the whole
+        // ClickParams schema (which also carries a query string and tags). ClickParams types both IDs as non-nullable
+        // strings without initialising them, so isset() is the only safe way to read them
+        $body = [];
+
+        if (isset($params->request_id)) {
+            $body['request_id'] = $params->request_id;
+        }
+
+        if (isset($params->document_id)) {
+            $body['document_id'] = $params->document_id;
+        }
+
+        $this->body = $body;
     }
 
 }

--- a/tests/Service/Requests/ClickPostTest.php
+++ b/tests/Service/Requests/ClickPostTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\DiscovererBifrost\Tests\Service\Requests;
+
+use Elastic\EnterpriseSearch\AppSearch\Schema\ClickParams;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\DiscovererBifrost\Service\Requests\ClickPost;
+
+class ClickPostTest extends SapphireTest
+{
+
+    public function testRequestTargetsTheBifrostClickEndpoint(): void
+    {
+        $request = ClickPost::create('my-engine', $this->createParams())->getRequest();
+
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('/api/v1/my-engine/click', $request->getUri()->getPath());
+        $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'));
+    }
+
+    public function testEngineNameIsEncoded(): void
+    {
+        // The engine name reaches us from the _searchAnalytics query param, so it must not be able to escape its path
+        // segment
+        $request = ClickPost::create('../../not-my-engine', $this->createParams())->getRequest();
+
+        $this->assertEquals('/api/v1/..%2F..%2Fnot-my-engine/click', $request->getUri()->getPath());
+    }
+
+    public function testBodyContainsOnlyTheIdsBifrostAccepts(): void
+    {
+        $params = $this->createParams();
+        // Neither of these are part of the Bifröst contract, and both should be dropped
+        $params->query = 'some search term';
+        $params->tags = ['tag-one'];
+
+        $request = ClickPost::create('my-engine', $params)->getRequest();
+
+        $this->assertEquals(
+            [
+                'request_id' => 'request-123',
+                'document_id' => 'document-456',
+            ],
+            json_decode((string) $request->getBody(), true)
+        );
+    }
+
+    public function testBodyOmitsIdsThatWereNeverSet(): void
+    {
+        // ClickParams types request_id as a non-nullable string but does not initialise it, so reading it unguarded
+        // would be a fatal error rather than a missing key
+        $request = ClickPost::create('my-engine', new ClickParams('some search term', 'document-456'))->getRequest();
+
+        $this->assertEquals(['document_id' => 'document-456'], json_decode((string) $request->getBody(), true));
+    }
+
+    private function createParams(): ClickParams
+    {
+        $params = new ClickParams('', 'document-456');
+        $params->request_id = 'request-123';
+
+        return $params;
+    }
+
+}


### PR DESCRIPTION
Follow-ups from reviewing #18. Targets `click-analytics` so they can land together — the backport itself is sound, these are around the edges of it.

### Fix the phpcs ruleset (`c482116`)

CI's `phplinting` job is failing on this branch, and it's two problems stacked, the second hidden behind the first:

- PHP_CodeSniffer 4.0.0 dropped support for passing an array of values to a property as a comma-separated string. That aborted the run with exit code 16 **before a single file was sniffed**. The `<element>` form is understood by both 3.x and 4.x.
- With the run no longer aborting, a newer Slevomat release flags `ClientFactory`'s class constants as missing native type hints. Typed class constants are PHP 8.3+ and this module supports PHP 8.1, so the sniff is excluded rather than satisfied.

`phpcs` now exits 0. Both are environment drift, not anything #18 introduced — this branch last ran green before either release.

### Keep `ClickPost` backwards compatible (`085b5d9`)

`ClickPost` is public API of a public module. Changing its parent class and its constructor from `(string, ?ClickParams)` to `(string, string, string)` breaks any project that instantiates or subclasses it, and it forced the removal of the `LogClickthrough` → `ClickPost` Injector mapping, which is its own behaviour change for anyone resolving that service.

It now keeps `extends LogClickthrough` and the original signature, and narrows `$this->body` after calling the parent. The payload on the wire is unchanged — still just `request_id` and `document_id`, with the query string and tags dropped — and `_config/requests.yml` goes back to identical to `2`.

Note `ClickParams` types both IDs as non-nullable strings *without initialising them*, so `isset()` is the only safe way to read them; `??` and `?->` both fatal on an uninitialised typed property.

Also URL-encodes the engine name in the path. It reaches this class from the base64 `_searchAnalytics` query param via `AnalyticsMiddleware`, so it isn't fully trusted input, and the v3 client already encodes it.

### Log every unsuccessful response (`1617c72`)

Only logging 5xx meant the most likely failure — a query API key without the click-analytics permission, which comes back as a 4xx — vanished with no trace at all. Now logs anything outside 2xx.

Still log-only and inside the existing try/catch: analytics must never change the response of the page the click was collected on.

### Add a `ClickPost` test (`92234ba`)

The request body is assembled by hand rather than by a generated client, so nothing else would catch it drifting from the API contract. Covers the method, path and content type, that the engine name can't escape its path segment, and that only the two IDs are sent.

### Drop the Injector fallbacks (`89bed10`)

`getSearchClient()` and `logWarning()` guarded against a null client and logger. That turned out to be a local dev artefact rather than something that happens in a deployed site — `BaseAdaptor` declares both as `$dependencies` and the adaptor is always built through Injector. Removed, so the adaptor now matches version 3's structure.

---

**Verified locally:** `phpcs` exits 0 across all 13 files; `phpunit` runs 8 tests / 10 assertions with the 4 new ones green. The one failure is `ClientFactoryTest::tearDownAfterClass` — "Connection refused" dropping the temp database, because there's no MySQL in my checkout. It's pre-existing and hits the untouched test too; CI has a database.

**Worth a release note on #18 either way:** BC is restored, but sites that still have `SEARCH_ANALYTICS_ENABLED` set will silently resume sending click traffic on upgrade, having been told by the previous release to remove that env var.
